### PR TITLE
New Options, Generalizations, Thoughts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # parsevcf
 
-## python script
+## Dependencies
+
+Requires BCFtools for an optional tag cleanup step.  
+```
+conda install -c bioconda bcftools
+```
+
+## Python script
+```
+git clone https://github.com/lilymaryam/parsevcf
+cd parsevcf
+python3 vcf_to_diff_script.py --help
+```
 
 ## WDL script
 The WDL task does not run on its own as a workflow -- it is meant to imported in a WDL workflow. It is used by the [myco](github.com/aofarrel/myco) pipeline.

--- a/vcf_to_diff_script.py
+++ b/vcf_to_diff_script.py
@@ -1271,23 +1271,27 @@ def missing_check(lenref, ld):
 
 #you can  assume sane people will end their gzipped files with .gz.
 #and it erroring if they don't is perfectly acceptable. 
-# try:
-if vcf[:-3] == '.gz':
-    lenRow, samps = count_samples_bin(vcf)
-else:
-    lenRow, samps = count_samples(vcf)
-# except:
-#     logging.error("Fail to read input vcf- check formatting.")
-#     sys.exit(1)
+try:
+    if vcf[:-3] == '.gz':
+        lenRow, samps = count_samples_bin(vcf)
+    else:
+        lenRow, samps = count_samples(vcf)
+except IndexError:
+    logging.error("Fail to read input vcf columns- check formatting.")
+    sys.exit(1)
 
 #be careful w dictionaries!!!
 files = make_files(samps, wd)
 
-if vcf[:-3] == '.gz':
-    read_VCF_bin(vcf, files)
-else:
-    read_VCF(vcf, files)
-    
+try:
+    if vcf[:-3] == '.gz':
+        read_VCF_bin(vcf, files)
+    else:
+        read_VCF(vcf, files)
+except IndexError:
+    logging.error("Fail to read input vcf data- check formatting.")
+    sys.exit(1)
+
 if tbmf != None:
     masks = mask_TB(tbmf)
 else:

--- a/vcf_to_diff_script.py
+++ b/vcf_to_diff_script.py
@@ -47,13 +47,12 @@ if wd[-1] != '/':
 if not os.path.exists(wd):
     os.mkdir(wd)
 
-#Functions                        
 def find_snps(line):
     '''
     for lines where len(ref)==len(alt), look for snps instead of processing as one large chunk 
-    args: 
+    Args: 
         line: a list containg the line from the VCF
-    output:
+    Returns:
         lines: a list of lists of lines to be added to the diff file 
     '''
     ref = line[3]
@@ -75,7 +74,7 @@ def process_dels(line):
     for lines where len(ref) > 1 AND len(alt) == 1 (currently deletions and missing data are all converted to '-')
     Args: 
         line: a list containing info from a line of the VCF
-    output:
+    Returns:
         l: a list containing the diff-formatted version of the deletion
     '''
     ref = line[3]
@@ -121,7 +120,7 @@ def mask_TB(tbmf):
     note: bed coverage file is 0 indexed, so 1 added to everything 
     Args:
         tbmf: bed file with positions to be ignored (note positions are assumed to be 0 indexed)
-    Output:
+    Returns:
         tb_sites: dictionary where key is start of masked region (1 index) and value is end of masked region (not inclusive)
     '''
     tb_sites = {}
@@ -148,7 +147,7 @@ def mask_low_depth(cf, cd):
         for line in cf:
             #might need to delete or change this
             #for currect bed coverage file 
-            if line.startswith(refname): #hardcoded chromosome name- naughty.
+            if line.startswith(refname):
                 line = line.strip().split()
                 #re-index to match VCF
                 line[1] = str(int(line[1])+1)
@@ -184,7 +183,7 @@ def check_prev_mask(prev, line):
     Args:
         prev: a list of the start and stop of the previously added mask region 
         line: a list of the start and stop of the to-be-added mask region
-    Output:
+    Returns:
         overlap: a boolean meant to indicate if prev and line overlap
         change: a list containing important information for updating the prev value
     '''
@@ -223,7 +222,7 @@ def condense_mask_regions(ld_sites,tb_sites):
     Args: 
         ld_sites: a dictionary containing low-depth sites to be masked
         tb_sites: a dictionary containing universal masking sites 
-    Output:
+    Returns:
         all_sites: a dictionary containing all masking sites from both universal and low-depth
     '''
     #editing thought: would likely benefit from being a list rather than a dictionary 
@@ -571,7 +570,7 @@ def count_samples(vcf):
     '''
     opens VCF and determines how many samples it has (note that this assumes 9cols of metadata)
     *note that VCF is 1-indexed and will remain as such
-    args: 
+    Args: 
         vcf: uncompressed VCF containing >=1 samples
     returns:
         lenRow: an int that determines number of columns in VCF (including metadata)
@@ -595,7 +594,7 @@ def count_samples_bin(vcf):
     '''
     opens VCF and determines how many samples it has (note that this assumes 9cols of metadata)
     *note that VCF is 1-indexed and will remain as such
-    args: 
+    Args: 
         vcf: compressed VCF containing >=1 samples
     returns:
         lenRow: an int that determines number of columns in VCF (including metadata)
@@ -786,12 +785,12 @@ def check_prev_line(prev, line):
 def mask_and_write_diff(ld, tb_masks, lines, samps):
     '''
     iterate through masking regions and lines of diff file to mask positions
-    args:
+    Args:
         ld: a dictionary of low depth coverage regions 
         tb_masks: a dictionary of universally masked regions
         lines: a list of diff-formatted lines 
         samps: a list of sample names from the VCF
-    output:
+    Returns:
         all_lines: a list of diff-formatted lines including all of the masked regions
     '''
     

--- a/vcf_to_diff_script.py
+++ b/vcf_to_diff_script.py
@@ -1271,12 +1271,13 @@ def missing_check(lenref, ld):
 
 #you can  assume sane people will end their gzipped files with .gz.
 #and it erroring if they don't is perfectly acceptable. 
-if vcf.endswith(".vcf"):
+if vcf.endswith('.vcf'):
     binary = False
-if vcf.endswith('.vcf.gz'):
+elif vcf.endswith('.vcf.gz'):
     binary = True
 else:
     logging.error("Unsupported file extension for input- use '.vcf' or '.vcf.gz'.")
+    logging.debug(f"File name read: {vcf}. Extension detected: {vcf.split('.')[-1]}")
     exit(1)
 
 try:

--- a/vcf_to_diff_script.py
+++ b/vcf_to_diff_script.py
@@ -1325,7 +1325,7 @@ for f in files:
     filepath = files[f].name
     if args.tag_filter:
         os.system(f"bcftools annotate -x '^FORMAT/GT' -O v -o {filepath}.filt {filepath}")
-        os.system(f"rm {filepath}")
+        os.remove(filepath)
         filepath = f"{filepath}.filt"
     if ld != None:
         #currently quality assessment requires a coverage file, if not coverage is provided the script will fail 

--- a/vcf_to_diff_script.py
+++ b/vcf_to_diff_script.py
@@ -1,32 +1,51 @@
 import os
+import sys
 import argparse
 import gzip
 import logging
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(description="Tool for converting VCF to diff formats.")
 parser.add_argument('-v', '--VCF', required=True, type=str,help='path to VCF to be processed')
-parser.add_argument('-d', '--working_directory', required=True, type=str, help='directory for all outputs (make sure this directory will have enough space!!!!)')
-parser.add_argument('-tbmf', '--tb_maskfile', required=True, type=str, help='directory for all outputs (make sure this directory will have enough space!!!!)')
+parser.add_argument('-d', '--working_directory', required=False, default='./', type=str, help='Output directory for storing intermediate and sample-level outputs.')
+parser.add_argument('-mf', '--maskfile', required=False, type=str, help='Masking data in BED format.')
 parser.add_argument('-cf', '--bed_coverage_file', required=False, type=str, help="path to bed coverage file for vcf (note: can only be used with single-sample vcfs)")
 parser.add_argument('-cd', '--coverage_depth', required=False, default=10, type=int, help="path to bed coverage file for vcf (note: can only be used with single-sample vcfs)")
-parser.add_argument('-l', '--logging', required=False, default=False, type=bool, help="if True, logging.debug verbose logging to stdout, else suppress most logging")
-
+parser.add_argument("-ha", "--haploid", action='store_true', help='Indicate whether the VCF is diploid or haploid. Default is diploid.')
+#https://stackoverflow.com/questions/14097061/easier-way-to-enable-verbose-logging
+parser.add_argument(
+    '-D', '--debug',
+    help="Pring debugging statements.",
+    action="store_const", dest="loglevel", const=logging.DEBUG,
+    default=logging.WARNING,
+)
+parser.add_argument(
+    '-V', '--verbose',
+    help="Verbose output.",
+    action="store_const", dest="loglevel", const=logging.INFO,
+)
+parser.add_argument("-r", "--reference_length", default=4411532, type=int, help="Length of the reference genome. Default is 4411532 (length of the TB genome).")
+parser.add_argument("-rn", "--reference_name", default='NC_000962.3', help='Name of the reference genome. Default is "NC_000962.3", the TB reference.')
+parser.add_argument('-t', "--tag_filter", action='store_true', help='Use to filter GT tags in input vcfs. Requires BCFtools.')
+parser.add_argument("-sp", "--split_diff", action='store_true', help='Use to create separate .diff files for each of your input samples.')
+parser.add_argument("-mr", "--mask_report", action='store_true', help='Print sample level text reports of masking information.')
+parser.add_argument("-od", "--output_diff", help='Name of a compiled output diff.')
 args = parser.parse_args()
 vcf = args.VCF
 wd = args.working_directory
-tbmf = args.tb_maskfile
+tbmf = args.maskfile
 cf = args.bed_coverage_file
 cd = args.coverage_depth
-if args.logging is True:
-    logging.basicConfig(level=logging.DEBUG)
-else:
-    logging.basicConfig(level=logging.WARNING)
+refname = args.reference_name
+logging.basicConfig(level=args.loglevel)
 
-len_ref = 4411532
+len_ref = args.reference_length
 
 #makes sure input path wont cause error
 if wd[-1] != '/':
     wd = wd+'/'
+#create the directory if it does not exist.
+if not os.path.exists(wd):
+    os.mkdir(wd)
 
 #Functions                        
 def find_snps(line):
@@ -120,7 +139,7 @@ def mask_low_depth(cf, cd):
     Args: 
         cf: path to bed coverage file 
         cd: integer indicating coverage depth needed 
-    out:
+    Returns:
         ld_sites: dictionary of low-depth sites needing to be masked 
     '''
     ld_sites = {}
@@ -129,7 +148,7 @@ def mask_low_depth(cf, cd):
         for line in cf:
             #might need to delete or change this
             #for currect bed coverage file 
-            if line.startswith('NC_000962.3'):
+            if line.startswith(refname): #hardcoded chromosome name- naughty.
                 line = line.strip().split()
                 #re-index to match VCF
                 line[1] = str(int(line[1])+1)
@@ -153,7 +172,7 @@ def mask_low_depth(cf, cd):
                             prev = [int(line[1]), int(line[2])]
     #this conditional might need to be fixed if there are no low-coverage areas
     if ld_sites == {}:
-        raise Exception('coverage file has incorrect reference')
+        raise Exception('coverage file contains no low-coverage areas- check input.')
 
     return ld_sites
 
@@ -386,7 +405,7 @@ def squish(lines):
 def vcf_to_diff(vcf_file):
     '''
     takes a single sample vcf and converts to diff format
-    NOTE: this function makes the assumption that incoming diff file is genotyped as diploid
+    NOTE: this function makes the assumption that incoming vcf file is genotyped as diploid
           (it's common practice to call variants on TB as if it were diploid)
     Args: 
         vcf_file: uncompressed single sample vcf 
@@ -421,6 +440,11 @@ def vcf_to_diff(vcf_file):
                     #combine ref allele and alt alleles
                     alleles = [line[3]] + line[4].split(',')
                     
+                    if args.haploid:
+                        #make it a fake homozygous diploid. hack solution.
+                        #TODO: something smarter than this.
+                        var = var + "/" + var
+
                     #if genotype is not reference allele
                     if var != '0/0':
                         #logging.debug("Not a reference allele")
@@ -434,7 +458,7 @@ def vcf_to_diff(vcf_file):
                             #potentially useful to track number of positions with missing info 
                             #missing += int(len(line[3]))
                             line[4] = '-'
-                            line [-1] = '1'
+                            line[-1] = '1'
                             #logging.debug("Missing info")
                             #logging.debug('missing', line)
 
@@ -777,11 +801,14 @@ def mask_and_write_diff(ld, tb_masks, lines, samps):
         
     #else:
     #    masks = tb_masks
-    masks = ld
-    masks_key = sorted(ld.keys())
-    logging.info("Masking the diff file...")
-    logging.debug('masks', masks_key, masks)
-    
+    if ld != None:
+        masks = ld
+        masks_key = sorted(ld.keys())
+        logging.info("Masking the diff file...")
+        logging.debug('masks', masks_key, masks)
+    else:
+        masks = {}
+        masks_key = masks.keys()
     # iterate through all masks and lines one time and combine things as needed
     masks_ind = 0
 
@@ -1243,32 +1270,35 @@ def missing_check(lenref, ld):
 
 #SCRIPT STARTS HERE
 
-binary = True
-with gzip.open(vcf, 'r') as test:
-    try:
-        test.read(1)
-    except OSError:
-        binary = False
-
-if binary == True:
+#you can  assume sane people will end their gzipped files with .gz.
+#and it erroring if they don't is perfectly acceptable. 
+# try:
+if vcf[:-3] == '.gz':
     lenRow, samps = count_samples_bin(vcf)
 else:
     lenRow, samps = count_samples(vcf)
+# except:
+#     logging.error("Fail to read input vcf- check formatting.")
+#     sys.exit(1)
 
 #be careful w dictionaries!!!
 files = make_files(samps, wd)
 
-if binary == True:
+if vcf[:-3] == '.gz':
     read_VCF_bin(vcf, files)
-    
 else:
     read_VCF(vcf, files)
     
-masks = mask_TB(tbmf)
+if tbmf != None:
+    masks = mask_TB(tbmf)
+else:
+    #default to no masking.
+    masks = {}
 #this is not parallelized, the more samples in the vcf the longer this will take
 #logging.debug(files)
 #logging.debug(masks)
 
+final_lines = []
 for f in files:
     files[f].close()
 
@@ -1282,26 +1312,36 @@ for f in files:
     sample = os.path.basename(files[f].name)[:-4]
     logging.info('Working on sample', sample)
     filepath = files[f].name
-    os.system(f"bcftools annotate -x '^FORMAT/GT' -O v -o {filepath}.filt {filepath}")
-    os.system(f"rm {filepath}")
-
-    #currently quality assessment requires a coverage file, if not coverage is provided the script will fail 
-    error = missing_check(len_ref, ld)
+    if args.tag_filter:
+        os.system(f"bcftools annotate -x '^FORMAT/GT' -O v -o {filepath}.filt {filepath}")
+        os.system(f"rm {filepath}")
+        filepath = f"{filepath}.filt"
+    if ld != None:
+        #currently quality assessment requires a coverage file, if not coverage is provided the script will fail 
+        error = missing_check(len_ref, ld)
+    else:
+        error = 'nomask'
 
     #if there is a provided coverage file it will be used to mask low coverage (less than cd) regions 
     #note that only one coverage file can be provided and it will result in an error if the vcf has more samples than coverage files 
-    lines = vcf_to_diff(f'{filepath}.filt')
-    os.system(f'rm {filepath}.filt')
+    lines = vcf_to_diff(filepath)
+    os.remove(filepath)
 
     all_lines = mask_and_write_diff(ld, masks,lines, samps)
     
     logging.info('MASK2REF')
-    final_lines = mask2ref(all_lines, masks)
+    filtered_lines = mask2ref(all_lines, masks)
+    if args.mask_report:
+        with open(f'{wd}{sample}.report.txt','w') as o:
+            o.write(f'{sample}.diff\t{error}\t{cd}\n')
+    if args.split_diff:
+        with open(f'{wd}{sample}.diff','w') as o:
+            for line in filtered_lines:
+                o.write('\t'.join(line)+'\n')
+    final_lines.extend(filtered_lines)
 
-    with open(f'{wd}{sample}.report','w') as o:
-        o.write(f'{sample}.diff\t{error}\t{cd}\n')
-    with open(f'{wd}{sample}.diff','w') as o:
-        for line in final_lines:
-            o.write('\t'.join(line)+'\n')
-    
+with open(args.output_diff,'w+') as of:
+    for line in final_lines:
+        print('\t'.join(line),file=of)
+
 logging.info("Finished")

--- a/vcf_to_diff_script.py
+++ b/vcf_to_diff_script.py
@@ -1271,8 +1271,16 @@ def missing_check(lenref, ld):
 
 #you can  assume sane people will end their gzipped files with .gz.
 #and it erroring if they don't is perfectly acceptable. 
+if vcf.endswith(".vcf"):
+    binary = False
+if vcf.endswith('.vcf.gz'):
+    binary = True
+else:
+    logging.error("Unsupported file extension for input- use '.vcf' or '.vcf.gz'.")
+    exit(1)
+
 try:
-    if vcf[:-3] == '.gz':
+    if binary:
         lenRow, samps = count_samples_bin(vcf)
     else:
         lenRow, samps = count_samples(vcf)
@@ -1282,9 +1290,8 @@ except IndexError:
 
 #be careful w dictionaries!!!
 files = make_files(samps, wd)
-
 try:
-    if vcf[:-3] == '.gz':
+    if binary:
         read_VCF_bin(vcf, files)
     else:
         read_VCF(vcf, files)


### PR DESCRIPTION
This PR contains a bunch of new options I wrote to disable some of the more expensive/messy default behaviors and removes some assumptions about the user passing masking information and diploid data. It is in no way comprehensive for every change I might want to make, but it was able to accomplish my immediate goal of making a diff from a minimal matUtils produced VCF. I tested it with the following commands:

```
matUtils extract -i public-latest.all.masked.pb.gz -z 20 -v test.vcf
python3 parsevcf/vcf_to_diff_script.py -v test.vcf -ha -od test.diff
```

PLEASE NOTE: while all original behavior can be reproduced with the correct options, I did turn off some things by default- like producing masking reports for every sample. I also did not touch the WDL. The WDL commands will need to be updated accordingly to keep your behavior consistent if you merge this! You should also test this on your existing data just to make sure I didn't break anything!

Some things I changed:
1. Cleaned up arguments and helpstrings. Better logging level setting. 
2. Make reference length and name into options instead of hardcoded assumptions. Default is the TB genome name/length (so same as previous behavior)
3. Make the numerous masking steps optional. Set default behaviors for when no masking information is passed.
4. Make the bcftools call step optional, as well as the overall masking being optional. 
5. Alter output behavior. Writing masking reports and diffs for every single sample is now optional and off by default. The user can get a single concatenated diff with the new option -od.
6. Add (simple) haploid support and and associated option- haploids are treated as homozygous diploids. Please make sure this doesn't have any unintended consequences.
7. Adjusted handling of gzipped input/vcf input in general. Your users will have ".vcf.gz" at the end of their files if their files are gzipped, so just check for that. And if they don't, the user is in the wrong! Additionally, just checking whether its binary could lead to problems if they used other compression formats. Added some try/catch as well. 
8. Basic installation/usage to README
9. General docstring tweaks.

Some general thoughts:

Keeping giant commented-out blocks of code is never a good look- makes it hard to navigate. You can always find old code in your github history if you need it in the future. Similarly, just go ahead and enable the debug-level logging statements for the debug-level- and if you don't want them even there, then just delete them!

There's an implementation question re: disk versus memory use. Right now you split a VCF by writing it iteratively to disk. This gets around loading extremely large files into memory- valuable, but I/O bound and potentially messy. Loading it into memory, comparatively, is simpler and means your work will not be I/O bound, but means you need to have a lot of things in RAM. You may want to consider supporting either behavior- disk writing sample-level variation as an optional behavior for users with extremely large VCF. This is more of a long-term thing to consider than a requirement, though. 

Ideally, the final version of this will not call bcftools at any point. Other than that one step its dependency-free, and that will make maintaining, distributing, and using this tool much easier! If you could replicate the bcftools behavior in Python or just remove that step altogether, it would go a way towards making this more of an independent software tool.

Masking is a huge part of what this script is doing. I've done some super simple additions to the README, but a brief overview of the diff format and details on your masking parameters would be critical additions to the documentation. 

Let me know your thoughts. This is a generally impressive piece of work (appreciate the use of logging and docstrings), though in need of some TLC in terms of organization/clarity. If you'd like to chat about what this would need to get published on pip, let me know!